### PR TITLE
fix: remove aliases that cause shell prompts to hang in the Warp terminal

### DIFF
--- a/dotfiles/.zshrc
+++ b/dotfiles/.zshrc
@@ -102,14 +102,26 @@ source ${ZSH}/oh-my-zsh.sh
 # aliases
 # ------------------------------------------------------------------- #
 
-# system
-alias cat=batcat
-alias cp='cp -i'
-alias mv='mv -i'
-alias rm='/bin/rm -i'
 alias ls=lsd
-alias lsl='ls -haltr'  # -halter  the `-e` is part of the `-l`
 alias sl="ls | rev"
+alias lsl='ls -haltr'  # -halter  the `-e` is part of the `-l`
+
+# Selectively enable features for non-Warp terminals.
+if [[ $TERM_PROGRAM != "WarpTerminal" ]]; then
+  # Aliasing batcat to cat will cause the autocomplete to slow down randomly.
+  alias cat=batcat
+
+  # Forcing interactive mode with system commands like cp, mv, rm will cause the
+  # shell prompt to hang randomly. Even in non-Warp terminals forcing this
+  # option causes hard to debug issues with shell scripts running under this zsh
+  # session. Only uncomment this if you are absolutely sure this won't cause
+  # issues.
+  #if [[ -o interactive ]]; then
+  #  alias cp='cp -i'
+  #  alias mv='mv -i'
+  #  alias rm='rm -i'
+  #fi
+fi
 
 # git
 alias grr='git reset HEAD~1'


### PR DESCRIPTION
[Warp](https://www.warp.dev/) terminal uses system level commands in non-interactive background processes to enable things like command auto-completion, syntax highlighting, etc. in [subshells](https://docs.warp.dev/features/subshells).

Aliasing `cp`, `mv`, `rm` to force interactive mode causes the prompt to hang since Warp uses these commands while executing [non-interactive background commands](https://docs.warp.dev/features/subshells#background-commands). 

Additionally, forcing interactive mode also causes issues that are not so obvious when calling shell scripts which use these commands that are executed by the user in the current zsh context since `-i` overrides `-f` option.

The PR also unaliases `cat` for Warp terminal since it has shown to cause slowdowns for  prompts in Warpified subshells as well.